### PR TITLE
Slightly change the original api to make the get truly polymorphic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ReJotai
 
-Binding for the [Jotai](https://github.com/pmndrs/jotai) library
+Bindings for the [Jotai](https://github.com/pmndrs/jotai) library
+
+The bindings aim to be as close as possible to the original API, and introduces only a little runtime code only when absolutely necessary (see the derived atom sections below).
 
 ## API
 
@@ -22,6 +24,15 @@ module App = {
 
 ### Atoms
 
+#### `Jotai.get`
+
+Unlike the original API, and in order to keep the flexibility, derived atoms requires some light runtime code and small changes to the semantic: `get` is now `getter` (see `derivedAtom` and `derivedAsyncAtom` for more).
+
+```rescript
+// Inside a derived atom
+let value = getter->Jotai.get(atom)
+```
+
 #### `Jotai.atom`
 
 Creates a simple readable/writable atom:
@@ -33,15 +44,15 @@ let counterAtom = Jotai.atom(10)
 #### `Jotai.derivedAtom`
 
 ```rescript
-let doubleCounterDerivedAtom = Jotai.derivedAtom(get => get(counterAtom) * 2)
+let doubleCounterDerivedAtom = Jotai.derivedAtom(getter => getter->Jotai.get(counterAtom) * 2)
 ```
 
 #### `Jotai.derivedAsyncAtom`
 
 ```rescript
-let asyncDerivedAtom = Jotai.derivedAsyncAtom(get =>
+let asyncDerivedAtom = Jotai.derivedAsyncAtom(getter =>
   Js.Promise.make((~resolve, ~reject as _) => {
-    let tripleCounter = get(counterAtom) * 3
+    let tripleCounter = getter->Jotai.get(counterAtom) * 3
 
     Js.Global.setTimeout(() => resolve(. tripleCounter), 300)->ignore
   })
@@ -83,5 +94,4 @@ You can check the [tests](test/Main_Test.res) for more.
 
 ## Limitations
 
-- The `get` function in derived atoms currently supports only one type at a time (see this [issue](https://github.com/gaku-sei/re-jotai/issues/1) for more)
 - Some functions are still missing, namely: [`derivedWritableAtom`](https://github.com/gaku-sei/re-jotai/issues/2) and [`derivedAsyncWritableAtom`](https://github.com/gaku-sei/re-jotai/issues/3)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "clean": "bsb -clean-world && rm -fr lib",
     "build": "bsb -make-world",
-    "test": "yarn build && jest"
+    "test": "yarn build && jest",
+    "test:update": "yarn build && jest ----updateSnapshot"
   },
   "jest": {
     "testMatch": [

--- a/src/Jotai.res
+++ b/src/Jotai.res
@@ -8,23 +8,27 @@ type atom<'value, 'access> constraint 'access = [< rw]
 
 @module("jotai") external atom: 'value => atom<'value, rw> = "atom"
 
-@module("jotai")
-external derivedAtom: ((atom<'value, [> r]> => 'value) => 'derivedValue) => atom<'derivedValue, r> =
-  "atom"
+// Under the hood, get is a function that takes an atom and returns a value for this atom
+type getter
+
+@ocaml.doc(`A get function that takes a getter and an atom and returns the value contained by the atom`)
+let get = (type value, get: getter, atom: atom<value, [> r]>): value => Obj.magic(get, atom)
 
 @module("jotai")
-external derivedAsyncAtom: (
-  (atom<'value, 'access> => 'value) => Js.Promise.t<'derivedValue>
-) => atom<'derivedValue, r> = "atom"
+external derivedAtom: (getter => 'derivedValue) => atom<'derivedValue, r> = "atom"
+
+@module("jotai")
+external derivedAsyncAtom: (getter => Js.Promise.t<'derivedValue>) => atom<'derivedValue, r> =
+  "atom"
 
 @module("jotai")
 external useAtom: atom<'value, rw> => ('value, ('value => 'value) => unit) = "useAtom"
 
-@module("jotai")
-external useDerivedAtom': atom<'value, [> r]> => ('value, unit) = "useAtom"
+@module("jotai") @deprecated("Use useDerivedAtom instead")
+external useDerivedAtomInternal: atom<'value, [> r]> => ('value, unit) = "useAtom"
 
 let useDerivedAtom = atom => {
-  let (value, ()) = useDerivedAtom'(atom)
+  let (value, ()) = @ocaml.warning("-3") useDerivedAtomInternal(atom)
 
   value
 }

--- a/test/Main_Test.res
+++ b/test/Main_Test.res
@@ -8,11 +8,18 @@ let counterAtom = Jotai.atom(initialCounter)
 
 let messageAtom = Jotai.atom("Welcome Jotai!")
 
-let doubleCounterDerivedAtom = Jotai.derivedAtom(get => get(counterAtom) * 2)
+let mixedDerivedAtom = Jotai.derivedAtom(getter => {
+  let counter = getter->Jotai.get(counterAtom)
+  let message = getter->Jotai.get(messageAtom)
 
-let asyncDerivedAtom = Jotai.derivedAsyncAtom(get =>
+  {"counter": counter, "message": message}
+})
+
+let doubleCounterDerivedAtom = Jotai.derivedAtom(getter => getter->Jotai.get(counterAtom) * 2)
+
+let asyncDerivedAtom = Jotai.derivedAsyncAtom(getter =>
   Js.Promise.make((~resolve, ~reject as _) => {
-    let tripleCounter = get(counterAtom) * 3
+    let tripleCounter = getter->Jotai.get(counterAtom) * 3
 
     Js.Global.setTimeout(() => resolve(. tripleCounter), 300)->ignore
   })
@@ -35,9 +42,12 @@ module Counter = {
     let _counter = Jotai.useDerivedAtom(counterAtom)
     // let _doubleCounter = Jotai.useAtom(doubleCounterDerivedAtom)
     let doubleCounter = Jotai.useDerivedAtom(doubleCounterDerivedAtom)
+    let mixed = Jotai.useDerivedAtom(mixedDerivedAtom)
 
     <div>
       <div title="counter"> {counter->React.int} </div>
+      <div title="counter-2"> {mixed["counter"]->React.int} </div>
+      <div title="message"> {mixed["message"]->React.string} </div>
       <div title="doubled-counter"> {doubleCounter->React.int} </div>
       <React.Suspense fallback={<div> {"loading"->React.string} </div>}>
         <AsyncCounter />

--- a/test/__snapshots__/Main_Test.js.snap
+++ b/test/__snapshots__/Main_Test.js.snap
@@ -9,6 +9,16 @@ exports[`useCounter Counter is 42 1`] = `
       42
     </div>
     <div
+      title="counter-2"
+    >
+      42
+    </div>
+    <div
+      title="message"
+    >
+      Welcome Jotai!
+    </div>
+    <div
       title="doubled-counter"
     >
       84
@@ -32,6 +42,16 @@ exports[`useCounter Counter is 43 1`] = `
       title="counter"
     >
       43
+    </div>
+    <div
+      title="counter-2"
+    >
+      43
+    </div>
+    <div
+      title="message"
+    >
+      Welcome Jotai!
     </div>
     <div
       title="doubled-counter"


### PR DESCRIPTION
Closes https://github.com/gaku-sei/re-jotai/issues/1


The compromise and change introduced by this pr seems reasonable enough for now.

The JS api:
```js
const mixedDerivedAtom = derivedAtom(get => {
  const counter = get(counterAtom)
  const message = get(messageAtom)

  return {counter, message}
})
```

Can be translated to:

```rescript
let mixedDerivedAtom = Jotai.derivedAtom(getter => {
  let counter = getter->Jotai.get(counterAtom)
  let message = getter->Jotai.get(messageAtom)

  {"counter": counter, "message": message}
})
```

Semantically `get` is now `getter` and can be used only with `Jotai.get` that will hide the underlying types.