### PR TITLE
Fixed creating derived atoms from derived atoms

### DIFF
--- a/src/Atom.res
+++ b/src/Atom.res
@@ -38,7 +38,7 @@ type getter
 let value = getter->Jotai.Atom.get(atom)
 ```
 ")
-let get = (type value, get: getter, atom: t<value, 'value => 'value, [> Permissions.r]>): value =>
+let get = (type value, get: getter, atom: t<value, _, [> Permissions.r]>): value =>
   Obj.magic(get, atom)
 
 @ocaml.doc("An inhabited type used for the derived, write only, atoms")


### PR DESCRIPTION
After a hint from a user in the ReScript forum about the closed variant type, I was able to better understand the issue. It was actually about the constraint on the Atom type requiring a setter function is only valid on writable Atoms. I relaxed the constraint and the test seems to pass. However, maybe there's a better way to express that in ReScript?

Fixes #9 